### PR TITLE
add flake for automatic checking and fixing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652969555,
+        "narHash": "sha256-F+yPkuCudylgJvTIogiw6833Iis5tgFsVMMBisldS6s=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "00e9d7ab7a184d23027ee994771904d69dcc7c07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs: (
+    flake-utils.lib.eachDefaultSystem (system: {
+      lib = import ./lib.nix system inputs;
+
+      # `nix flake check` now checks format!
+      checks.format = self.lib.${system}.mkCheck self;
+
+      # `nix run .#format` formats in current directory!
+      apps.format = self.lib.${system}.mkFormatApp self;
+    }));
+}

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,132 @@
+system:
+
+{ self, nixpkgs, ... } @ inputs:
+
+let
+  pkgs = nixpkgs.legacyPackages.${system};
+  lib = pkgs.lib;
+
+  inherit (lib) getExe escapeShellArg;
+in
+
+rec {
+  mkTreefmtToml = srcTree:
+    let
+      filePresent = pattern:
+        import
+          (
+            pkgs.runCommandLocal "pattern-match.nix"
+              {
+                # Can be enabled once we recommend content addressing
+                # -- since we only generate one of two files.
+                # __contentAddressed = true;
+              }
+              ''
+                find ${escapeShellArg srcTree} -name ${escapeShellArg pattern} \
+                  | (grep . > /dev/null && echo "true" || echo "false") > $out
+              ''
+          );
+
+      formatters = {
+        terraform = {
+          command = getExe pkgs.bash;
+          options = [
+            "-euc"
+            ''
+              for f in "$@"; do
+                ${getExe pkgs.terraform} fmt "$f"
+              done
+            ''
+            "--"
+          ];
+          includes = [ "*.tf" ];
+        };
+
+        haskell = {
+          command = getExe pkgs.bash;
+          options =
+            # Fourmolu not having an option to specify the config is so dumb...
+            let fourmoluConfig = pkgs.runCommandLocal "fourmoluConfigHome" { } ''
+              mkdir $out
+              cp ${./fourmolu.yaml} $out/
+            '';
+            in
+            [
+              "-euc"
+              ''
+                export XDG_CONFIG_HOME=${fourmoluConfig}
+                ${getExe pkgs.haskellPackages.fourmolu} \
+                  -o-XImportQualifiedPost \
+                  "$@"
+              ''
+              "--"
+            ];
+          includes = [ "*.hs" ];
+        };
+
+        nix = {
+          command = getExe pkgs.nixpkgs-fmt;
+          includes = [ "*.nix" ];
+        };
+      };
+
+      filteredFormatters = lib.filterAttrs
+        (k: v: lib.any filePresent v.includes)
+        formatters;
+
+      treefmtStruct = {
+        formatter = formatters;
+      };
+
+      treefmtJson = pkgs.writeTextFile {
+        name = "treefmt.json";
+        text = builtins.toJSON treefmtStruct;
+      };
+
+      treefmtToml = pkgs.runCommandLocal "treefmt.toml" { } ''
+        ${getExe pkgs.remarshal} --if json --of toml ${treefmtJson} $out
+      '';
+    in
+    treefmtToml;
+  mkCheck = src:
+    pkgs.runCommandLocal "checked-src"
+      {
+        nativeBuildInputs = with pkgs; [ treefmt ];
+      }
+      ''
+        mkdir -p /tmp/home
+        export HOME=/tmp/home
+
+        # set -euxo pipefail
+        cp -r ${src} ./tree/
+        chmod -R u=rwx,go=rx tree
+
+        cd tree
+        # ls -la
+
+        CONFIG=${mkTreefmtToml src}
+        echo CONFIG: $CONFIG
+
+        treefmt --version
+        treefmt \
+          --config-file $CONFIG \
+          --tree-root . \
+          --fail-on-change \
+          -vv
+
+        touch $out
+      '';
+
+  mkFormatApp = src:
+    let
+      script = pkgs.writeScript "format" ''
+        set -euo pipefail
+
+        ROOT=./$(${getExe pkgs.git} rev-parse --show-cdup)
+        ${getExe pkgs.treefmt} --config-file ${mkTreefmtToml src} --tree-root $ROOT "$@"
+      ''; in
+    {
+      type = "app";
+      program = "${script}";
+    };
+}


### PR DESCRIPTION
Allows you to do cool stuff!

```nix
# `nix flake check` now checks format!
checks.format = styleguide.lib.${system}.mkCheck self;

# `nix run .#format` formats in current directory!
apps.format = styleguide.lib.${system}.mkFormatApp self;
````

Only relevant formatters are downloaded, so feel free to add "canonical" formatters (black, gofmt, etc.) for other languages.