### PR TITLE
Fix missing shebang in resulting script

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -121,7 +121,7 @@ rec {
       '';
 
   mkFormatter = src:
-    pkgs.writeScriptBin "format" ''
+    pkgs.writeShellScriptBin "format" ''
       set -euo pipefail
 
       ROOT=./$(${getExe pkgs.git} rev-parse --show-cdup)


### PR DESCRIPTION
Fix error below:
```console
$ nix fmt
error: unable to execute '/nix/store/g6fjsjrygxb8nfkfv4bkmi8z2q438qqp-format/bin/format': Exec format error
```